### PR TITLE
Fix use of $ORIGIN in dynamic links

### DIFF
--- a/rts/ghc.mk
+++ b/rts/ghc.mk
@@ -195,7 +195,8 @@ else
 ifneq "$$(UseSystemLibFFI)" "YES"
 LIBFFI_LIBS = -Lrts/dist/build -l$$(LIBFFI_NAME)
 ifeq "$$(TargetElf)" "YES"
-LIBFFI_LIBS += -optl-Wl,-rpath -optl-Wl,'$$$$ORIGIN' -optl-Wl,-zorigin
+LIBFFI_LIBS += -optl-Wl,-rpath -optl-Wl,'\$$$$ORIGIN' -optl-Wl,-zorigin
+# TODO: Check if '\$$$$ORIGIN' works with -fasm build path.
 endif
 
 else

--- a/rules/distdir-way-opts.mk
+++ b/rules/distdir-way-opts.mk
@@ -136,7 +136,8 @@ ifneq "$4" "0"
 ifeq "$$(TargetElf)" "YES"
 $1_$2_$3_GHC_LD_OPTS += \
     -fno-use-rpaths \
-    $$(foreach d,$$($1_$2_TRANSITIVE_DEPS),-optl-Wl$$(comma)-rpath -optl-Wl$$(comma)'$$$$ORIGIN/../$$d') -optl-Wl,-zorigin
+    $$(foreach d,$$($1_$2_TRANSITIVE_DEPS),-optl-Wl$$(comma)-rpath -optl-Wl$$(comma)'\$$$$ORIGIN/../$$d') -optl-Wl,-zorigin
+    # TODO: Check if '\$$$$ORIGIN' works with -fasm build path.
 else ifeq "$$(TargetOS_CPP)" "darwin"
 $1_$2_$3_GHC_LD_OPTS += -optl-Wl,-headerpad_max_install_names
 endif


### PR DESCRIPTION
With this small tweak I was able to build ghc with `DYNAMIC_GHC_PROGRAMS`, the `dyn` way and with the `llvm` backend. Using `ldd` on the generated .so files after installation all libraries are successfully found.

From my commit:

The great lengths to ensure $ORIGIN gets written into the runpath of the dynamic libraries needs just one more escape character. Previously, $$$$ORIGIN evaluates to $ORIGIN which was being evaluated by some step in the chain to either the empty string or \0. Escaping the dollar sign _one more time_ allows the $ to be passed to the linker unmolested.
